### PR TITLE
Fix docker build with incomplete wasm artifact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ RUN set -eux; curl https://sh.rustup.rs -sSf | sh -s -- -y && \
   curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s
 
 # Build rust dependencies
-RUN . ~/.cargo/env && USER=root cargo new --lib --name rl-web /usr/src/rl-web/crate
-COPY ./crate/Cargo.toml ./crate/Cargo.lock /usr/src/rl-web/crate/
-RUN . ~/.cargo/env && cd /usr/src/rl-web/crate && wasm-pack build --release
+COPY ./crate /usr/src/rl-web
+RUN . ~/.cargo/env && cd /usr/src/rl-web && wasm-pack build --release
 
 WORKDIR /usr/src/rl-web
 

--- a/assets/wasm-size-check.sh
+++ b/assets/wasm-size-check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+bytes=$(docker run --rm -i "$(docker build -q .)" find /usr/share/nginx/html -iname rl_wasm_bg.*.wasm -exec wc -c {} \; | cut -d " " -f1)
+[[ $bytes -lt 1000 ]] && echo "wasm generated incorrectly" && exit 1
+echo "done"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,3 +19,5 @@ steps:
     displayName: e2e tests
   - script: docker build .
     displayName: build docker image
+  - script: ./assets/wasm-size-check.sh
+    displayName: test wasm bundle size


### PR DESCRIPTION
Only the dependencies were compiled into wasm. This resulted in a tiny
wasm bundle, so add a test to count how many bytes are present