### PR TITLE
Reduce wasm bundle size

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -11,3 +11,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.55"
 boxcars = "0.6"
 serde_json = "1.0"
+
+[profile.release]
+lto = true
+opt-level = 'z'


### PR DESCRIPTION
Through a combination of llvm optimizing for size and wasm-opt from
binaryen. The wasm file shrunk from 670KB to 470KB.