### PR TITLE
Set browserslist to those that support await / async

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     }
   },
   "browserslist": [
-    "defaults",
-    "not explorer 10-11"
+    "since 2018-01",
+    "not kaios <= 2.5",
+    "not android < 80"
   ],
   "devDependencies": {
     "@types/jest": "^25.1.3",


### PR DESCRIPTION
Ref https://github.com/rustwasm/wasm-bindgen/issues/2034

This shouldn't effect anything as browsers that support web assembly or async tend to support the other one.