### PR TITLE
Overhaul wasm and js bridge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,9 @@ steps:
     displayName: Npm Install
   - script: './assets/build-wasm.sh'
     displayName: Build rust crate
+  - script: 'wasm-pack test --node'
+    workingDirectory: './crate'
+    displayName: Test rust crate
   - script: npm run type-check
     displayName: Typescript check
   - script: npm run unit

--- a/crate/Cargo.lock
+++ b/crate/Cargo.lock
@@ -49,6 +49,15 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "js-sys"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -224,11 +241,17 @@ dependencies = [
  "boxcars 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ryu"
 version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -308,6 +331,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +367,37 @@ name = "wasm-bindgen-shared"
 version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test-macro 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum bitter 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5eda7961e9ec30693e08246d7d34aced60a5b885dc077cc39bae04580914fb3"
@@ -341,11 +406,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -363,6 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_pcg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e196346cbbc5c70c77e7b4926147ee8e383a38ee4d15d58a08098b169e492b6"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
@@ -372,6 +440,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasm-bindgen 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
 "checksum wasm-bindgen-backend 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
+"checksum wasm-bindgen-futures 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "457414a91863c0ec00090dba537f88ab955d93ca6555862c29b6d860990b8a8a"
 "checksum wasm-bindgen-macro 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
 "checksum wasm-bindgen-macro-support 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
 "checksum wasm-bindgen-shared 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
+"checksum wasm-bindgen-test 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "449aeba7035e4a4710cd263bbac33519fa3828bff1c6f642fa8896601e7016ad"
+"checksum wasm-bindgen-test-macro 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "49449f8dcedc192bd0cf11b5711982decdd4dbad1029f92370e2b1215031dd59"
+"checksum web-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)" = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -5,12 +5,15 @@ authors = ["Nick Babcock <nbabcock19@hotmail.com>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2.59"
 boxcars = "0.7.1"
 serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [profile.release]
 lto = true

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,49 +1,60 @@
 use boxcars::{NetworkParse, ParserBuilder};
 use wasm_bindgen::prelude::*;
 
-fn parse_replay(data: &[u8], mode: NetworkParse, pretty: bool) -> String {
+fn parse_header(data: &[u8], pretty: bool) -> Result<String, JsValue> {
     let replay = ParserBuilder::new(data)
-        .with_network_parse(mode)
+        .with_network_parse(NetworkParse::Never)
         .on_error_check_crc()
         .parse();
 
-    let res = replay.map_err(|e| e.to_string()).and_then(|x| {
-        if pretty {
-            serde_json::to_string_pretty(&x)
-        } else {
-            serde_json::to_string(&x)
-        }
-        .map_err(|e| e.to_string())
-    });
+    replay
+        .map_err(|e| JsValue::from_str(e.to_string().as_str()))
+        .and_then(|x| {
+            let res = if pretty {
+                serde_json::to_string_pretty(&x)
+            } else {
+                serde_json::to_string(&x)
+            };
 
-    match res {
-        Ok(data) => data,
-        Err(ref e) => {
-            let mut result = String::from(r#"{"error":""#);
-            result.push_str(&e.to_string());
-            result.push('"');
-            result.push('}');
-            result
-        }
-    }
+            res.map_err(|e| JsValue::from_str(e.to_string().as_str()))
+        })
+}
+
+fn parse_network(data: &[u8], pretty: bool) -> Result<Vec<u8>, JsValue> {
+    let replay = ParserBuilder::new(data)
+        .with_network_parse(NetworkParse::Always)
+        .on_error_check_crc()
+        .parse();
+
+    replay
+        .map_err(|e| JsValue::from_str(e.to_string().as_str()))
+        .and_then(|x| {
+            let res = if pretty {
+                serde_json::to_vec_pretty(&x)
+            } else {
+                serde_json::to_vec(&x)
+            };
+
+            res.map_err(|e| JsValue::from_str(e.to_string().as_str()))
+        })
 }
 
 #[wasm_bindgen]
-pub fn parse_replay_header(data: &[u8]) -> String {
-    parse_replay(data, NetworkParse::Never, false)
+pub fn parse_replay_header(data: &[u8]) -> Result<String, JsValue> {
+    parse_header(data, false)
 }
 
 #[wasm_bindgen]
-pub fn parse_replay_network(data: &[u8]) -> String {
-    parse_replay(data, NetworkParse::Always, false)
+pub fn parse_replay_header_pretty(data: &[u8]) -> Result<String, JsValue> {
+    parse_header(data, true)
 }
 
 #[wasm_bindgen]
-pub fn parse_replay_header_pretty(data: &[u8]) -> String {
-    parse_replay(data, NetworkParse::Never, true)
+pub fn parse_replay_network(data: &[u8]) -> Result<Vec<u8>, JsValue> {
+    parse_network(data, false)
 }
 
 #[wasm_bindgen]
-pub fn parse_replay_network_pretty(data: &[u8]) -> String {
-    parse_replay(data, NetworkParse::Always, true)
+pub fn parse_replay_network_pretty(data: &[u8]) -> Result<Vec<u8>, JsValue> {
+    parse_network(data, true)
 }

--- a/crate/tests/test.rs
+++ b/crate/tests/test.rs
@@ -1,0 +1,52 @@
+use rl_wasm::*;
+use wasm_bindgen_test::*;
+
+const REPLAY: &'static [u8] = include_bytes!("../../assets/3d07e.replay");
+
+#[wasm_bindgen_test]
+fn test_parse_header() {
+    let res = parse_replay_header(&REPLAY[..]).unwrap();
+    assert!(res.contains(r#""header_size":6402,"#));
+}
+
+#[wasm_bindgen_test]
+fn test_parse_header_pretty() {
+    let res = parse_replay_header_pretty(&REPLAY[..]).unwrap();
+    assert!(res.contains(r#""header_size": 6402,"#));
+}
+
+#[wasm_bindgen_test]
+fn test_parse_header_bad() {
+    let err = parse_replay_header(b"lakjsdlasjdfal;")
+        .unwrap_err()
+        .as_string()
+        .unwrap();
+    assert!(err.contains("Could not decode replay header data"));
+}
+
+#[wasm_bindgen_test]
+fn test_parse_network() {
+    let res = parse_replay_network(&REPLAY[..])
+        .map(|x| String::from_utf8(x).unwrap())
+        .unwrap();
+    assert!(res.contains(r#""linear_velocity":{"#));
+}
+
+#[wasm_bindgen_test]
+fn test_parse_network_pretty() {
+    let res = parse_replay_network_pretty(&REPLAY[..])
+        .map(|x| String::from_utf8(x).unwrap())
+        .unwrap();
+    assert!(res.contains(r#""linear_velocity": {"#));
+}
+
+#[wasm_bindgen_test]
+fn test_parse_network_bad() {
+    let mut v = REPLAY.to_vec();
+    for i in 20000..30000 {
+        v[i] = 10;
+    }
+
+    let err = parse_replay_network(&v).unwrap_err().as_string().unwrap();
+    assert!(err.contains("Error decoding frame: attribute unknown or not implemented"));
+}

--- a/src/core/ReplayParser.ts
+++ b/src/core/ReplayParser.ts
@@ -12,9 +12,6 @@ export class ReplayParser {
   _parse(data: Uint8Array, fn: (arg0: Uint8Array) => string) {
     const raw = fn(data);
     const response = JSON.parse(raw);
-    if (response && response.error) {
-      throw new Error(response.error);
-    }
 
     return {
       raw,
@@ -22,24 +19,16 @@ export class ReplayParser {
     };
   }
 
-  _parse_network(data: Uint8Array, fn: (arg0: Uint8Array) => string) {
-    let response = fn(data);
-    if (response.length < 2048) {
-      let json = JSON.parse(response);
-      if (json && json.error) {
-        throw new Error(json.error);
-      }
-    }
-
-    return response;
+  _parse_network(data: Uint8Array, fn: (arg0: Uint8Array) => Uint8Array) {
+    return fn(data);
   }
 
   parse = (data: Uint8Array): DecodedReplay =>
     this._parse(data, parse_replay_header);
   parse_pretty = (data: Uint8Array): DecodedReplay =>
     this._parse(data, parse_replay_header_pretty);
-  parse_network = (data: Uint8Array): string =>
+  parse_network = (data: Uint8Array): Uint8Array =>
     this._parse_network(data, parse_replay_network);
-  parse_network_pretty = (data: Uint8Array): string =>
+  parse_network_pretty = (data: Uint8Array): Uint8Array =>
     this._parse_network(data, parse_replay_network_pretty);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -37,8 +37,10 @@ onmessage = async e => {
         break;
     }
   } catch (err) {
+    const msg = err instanceof Error ? err.message : err;
+
     // @ts-ignore
-    postMessage(["FAILED", err.message]);
+    postMessage(["FAILED", msg]);
   }
 };
 
@@ -83,6 +85,6 @@ function parseNetwork(pretty: boolean) {
     console.log(`${t1 - t0}ms`);
 
     // @ts-ignore
-    postMessage(["PARSED_NETWORK", replay]);
+    postMessage(["PARSED_NETWORK", replay.buffer], [replay.buffer]);
   }
 }


### PR DESCRIPTION
Have the network wasm endpoints directly return a `Vec<u8>`, which turns
into a Uint8Array instead of a String. The string for network data is a
wasteful middleman as wasm-bindgen converts the string to a byte array,
and since the blob which downloads the file doesn't care if it is a
string or an array buffer -- skip the intermediate string step.

Have the web worker use the byte array returned by the network wasm
endpoints and transfer it directly to the main UI thread instead of
needing a copy. This takes advantage of the transferable nature of an
`ArrayBuffer`: https://developer.mozilla.org/en-US/docs/Web/API/Transferable

Rewrite all wasm endpoints to return a Result so that we can remove the
heuristic on the JS side to try and detect if an error was embedded in
the returned string by detecting it's length.

Finally add tests to help against possible future regressions.

Overall, performance didn't seem to drastically change, but at least the
code is cleaner and tested.