### PR TITLE
Add cargo config to always target wasm

### DIFF
--- a/crate/.cargo/config.toml
+++ b/crate/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"


### PR DESCRIPTION
This makes it so the clippy and other tooling doesn't get overly confused -- we only target wasm builds here.